### PR TITLE
Add polyfill for str_starts_with on older PHP

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,6 +16,13 @@ error_reporting(E_ALL);
 
 session_start();
 
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool
+    {
+        return $needle === '' || strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
 const DB_FILE = __DIR__ . '/data.db';
 const APP_TITLE = 'RFID Sorter Assessment';
 const ENABLE_QUESTION_ADMIN = true;


### PR DESCRIPTION
## Summary
- add a polyfill for `str_starts_with` to keep the API routing logic working on PHP versions before 8

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc75d3545c8323b921c0a5f7af7346