### PR TITLE
Fix AI suggestion request authentication handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -748,9 +748,14 @@ function layout(string $content,string $title=APP_TITLE):void{
         const res = await fetch('ai.php', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
           body: JSON.stringify({ prompt, context })
         });
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          const message = data.error || `Erro HTTP ${res.status}`;
+          throw new Error(message);
+        }
         const input = btn.closest('.input-group').querySelector('input,textarea');
         if (data.suggestion) input.value = data.suggestion;
       } catch (e) {


### PR DESCRIPTION
## Summary
- include same-origin credentials in the AI suggestion fetch so authenticated sessions call the endpoint successfully
- surface AI endpoint errors to the UI when the response is not OK

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc81b8786c8323b6d67fc8e2f41fe5