### PR TITLE
Improve AI endpoint authentication and API key lookup

### DIFF
--- a/ai.php
+++ b/ai.php
@@ -4,7 +4,9 @@
 header('Content-Type: application/json; charset=utf-8');
 
 session_start();
-if (!isset($_SESSION['uid'])) {
+$hasUser = isset($_SESSION['uid']);
+$hasGuest = isset($_SESSION['guest_email']);
+if (!$hasUser && !$hasGuest) {
     http_response_code(401);
     echo json_encode(['error' => 'Não autenticado']);
     exit;
@@ -20,6 +22,15 @@ if (!$prompt) {
 }
 
 $apiKey = getenv("OPENAI_API_KEY");
+if (!$apiKey) {
+    $apiKey = ini_get('openai_api_key');
+}
+if (!$apiKey) {
+    $apiKey = $_ENV['OPENAI_API_KEY'] ?? $_SERVER['OPENAI_API_KEY'] ?? null;
+}
+if (is_string($apiKey)) {
+    $apiKey = trim($apiKey);
+}
 if (!$apiKey) {
     http_response_code(500);
     echo json_encode(['error' => 'OPENAI_API_KEY não definido']);


### PR DESCRIPTION
## Summary
- allow the AI suggestions endpoint to authenticate either logged-in or guest sessions
- fall back to .user.ini/ini values and server variables when resolving the OpenAI API key
- trim the resolved API key before calling OpenAI to avoid accidental whitespace issues

## Testing
- php -l ai.php

------
https://chatgpt.com/codex/tasks/task_e_68dc84826a08832392eba456b7c93e81